### PR TITLE
inserting card at correct location (before or after drop target card)

### DIFF
--- a/app/bscards/template.hbs
+++ b/app/bscards/template.hbs
@@ -24,5 +24,5 @@
 <div class="crack"></div>
 
 {{#each model.sections as |section|}}
-  {{layout-section model=section}}
+  {{layout-section-editor model=section}}
 {{/each}}

--- a/app/components/bs-row-editor/component.js
+++ b/app/components/bs-row-editor/component.js
@@ -1,7 +1,23 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  classNames:['rows'],
+  classNames:['row', 'bs-row-editor'],
+  eventBus: Ember.inject.service(),
+
+  // insert a card either at the begining
+  // or before/after the target card
+  _insertCard(card, targetCard, insertAfter) {
+    const cards = this.get('model.cards');
+    // where to insert?
+    // default to the begining (left)
+    let pos = 0;
+    if (targetCard) {
+      // if inserting before, use target card's current index
+      // otherwise (inserting after) use the next index
+      pos = cards.indexOf(targetCard) + (insertAfter ? 1 : 0);
+    }
+    cards.insertAt(pos, card);
+  },
 
   dragOver(event){
     //inform the DOM this is a drop target
@@ -9,13 +25,25 @@ export default Ember.Component.extend({
   },
   drop(event){
     console.log('bs-row-editor for ' + this.get('elementId') + ' caught drop');
-    this.get('model.cards').pushObject({
+    // TODO: are we adding a card or moving a card?
+    // for now only adding
+    // where to place the card?
+    let eventBus = this.get('eventBus');
+    let targetCard, insertAfter;
+    let dropCardInfo = eventBus.get('dropCardInfo');
+    if (dropCardInfo) {
+      targetCard = dropCardInfo.card;
+      insertAfter = dropCardInfo.insertAfter;
+    }
+    // TODO: what size should it be?
+    let newCard = {
       "width":4,
       "height": 4,
       "component": {"name": "placeholder-card"}
-    });
+    };
+    // insert the card
+    this._insertCard(newCard, targetCard, insertAfter);
+    // clear event bus state
+    eventBus.set('dropCardInfo', null);
   }
-
-
-
 });

--- a/app/components/bscard-editor/component.js
+++ b/app/components/bscard-editor/component.js
@@ -60,8 +60,8 @@ export default Ember.Component.extend({
     let crackcss = {
       display:"none"
     };
-    //default insertionPoint
-    let currentInsertionPoint = {};
+    // insert before or after this card? default to after
+    let insertAfter = false;
 
     /**
      * Determine if we are close to an edge...
@@ -78,8 +78,7 @@ export default Ember.Component.extend({
         "height":card.height,
         "width":"4px"
       };
-      currentInsertionPoint.x = this.get('model.x');
-      currentInsertionPoint.y = this.get('model.y');
+      insertAfter = false;
     }
 
     //Close to the right
@@ -93,16 +92,13 @@ export default Ember.Component.extend({
         "height":card.height,
         "width":"4px"
       };
-      currentInsertionPoint.x = this.get('model.x') + this.get('model.width');
-      currentInsertionPoint.y = this.get('model.y');
+      insertAfter = true;
     }
 
     //Close to the top
     //console.log( 'card.top:' + card.top + ' y: ' + mousePos.y +' prx: ' + (card.top + proximity));
     if(mousePos.y > card.top && mousePos.y < (card.top + yProximity) ){
 
-      currentInsertionPoint.x = this.get('model.x');
-      currentInsertionPoint.y = this.get('model.y');
       crackcss = {
         "display":"block",
         "background-color":"purple",
@@ -111,13 +107,12 @@ export default Ember.Component.extend({
         "height":"4px",
         "width":card.width
       };
+      insertAfter = false;
     }
 
     //Close to the bottom
     if(mousePos.y > (card.bottom - yProximity) && mousePos.y < (card.bottom) ){
 
-      currentInsertionPoint.x = this.get('model.x');
-      currentInsertionPoint.y = this.get('model.y') + this.get('model.height');
       crackcss = {
         "display":"block",
         "background-color":"navy",
@@ -126,11 +121,15 @@ export default Ember.Component.extend({
         "height":"4px",
         "width":card.width
       };
+      insertAfter = true;
     }
     //set the crack css
     Ember.$('.crack').css(crackcss);
-    //set the drop position
-    this.set('eventBus.dropPosition', currentInsertionPoint);
+    // set target card and before/after
+    this.set('eventBus.dropCardInfo', {
+      card: this.get('model'),
+      insertAfter
+    });
 
   },
 

--- a/app/components/bscard-editor/template.hbs
+++ b/app/components/bscard-editor/template.hbs
@@ -2,6 +2,7 @@
   <div class="clearfix card-editor-header">
     <div class="pull-left"><small> {{elementId}} </small></div>
     <div class="pull-right">
+      <span class="glyphicon glyphicon-move card-editor-drag-handle"/>
       <a href="#" {{action "editCard" model}}><span class="glyphicon glyphicon-cog"/></a>
       <a href="#" {{action "deleteCard" model}}><span class="glyphicon glyphicon-remove"/></a>
     </div>

--- a/app/components/layout-section-editor/component.js
+++ b/app/components/layout-section-editor/component.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName:'section',
+  classNames:['layout-section-editor'],
+  containerClass: Ember.computed('model.containment', function(){
+    let containment = this.get('model.containment');
+    return ( containment === 'fixed') ? 'container' : 'container-fluid';
+  }),
+  /**
+   * Get the event bus
+   */
+  eventBus: Ember.inject.service('event-bus'),
+
+});

--- a/app/components/layout-section-editor/template.hbs
+++ b/app/components/layout-section-editor/template.hbs
@@ -1,0 +1,5 @@
+<div class="{{containerClass}}">
+  {{#each model.rows as |row|}}
+    {{bs-row-editor model=row}}
+  {{/each}}
+</div>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,10 +1,12 @@
 $gray-dark: #333333;
 $link-color: #555555;
 
-
+@import 'layout-section-editor';
+@import 'bs-row-editor';
 @import 'layout-cards-editor';
-@import 'tom';
 @import 'bs-cards-editor';
+// TODO: replace w/ 1 per component, or remove?
+@import 'tom';
 
 .card-hover {
   background-color:purple;

--- a/app/styles/bs-row-editor.scss
+++ b/app/styles/bs-row-editor.scss
@@ -1,0 +1,4 @@
+.bs-row-editor {
+  // showz the rowz
+  // border: 2px solid green;
+}

--- a/app/styles/layout-section-editor.scss
+++ b/app/styles/layout-section-editor.scss
@@ -1,0 +1,1 @@
+// TODO: layout section editor styles

--- a/tests/integration/components/layout-section-editor/component-test.js
+++ b/tests/integration/components/layout-section-editor/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('layout-section-editor', 'Integration | Component | layout section editor', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{layout-section-editor}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#layout-section-editor}}
+      template block text
+    {{/layout-section-editor}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
replaced code from bscard-editor that sets target x/y on event bus
with code that sets target card and before/after based on edge proximity
also:
- using layout-section-editor component (instead of layout-section)
- stubbed in empty style sheets for components
- added card move drag icon, but didn't wire it up yet
