### PR TITLE
when moving rows, ghost whole row, not just handle

### DIFF
--- a/app/components/layout-row-editor/component.js
+++ b/app/components/layout-row-editor/component.js
@@ -8,6 +8,18 @@ export default Ember.Component.extend({
   classNameBindings: ['active'],
   active: false,
 
+  // set the drag image
+  _setDragImage(e) {
+    if (!e.dataTransfer || !e.dataTransfer.setDragImage) {
+      return;
+    }
+    const $row = this.$();
+    const $handle = this.$(e.target);
+    // b/c we're dragging from upper right corner,
+    // want to shift to the left by width of the element
+    e.dataTransfer.setDragImage($row[0], $row.outerWidth() - ($handle.outerWidth() / 2), $handle.outerHeight() / 2);
+  },
+
   dragEnter(e) {
     this.set('active', true);
     this.sendAction('onDragEnter', e, this.model);
@@ -32,6 +44,7 @@ export default Ember.Component.extend({
   actions: {
     onRowDragStart (e) {
       e.dataTransfer.setData('text/plain', 'moveRow');
+      this._setDragImage(e);
       this.sendAction('onStartMove', e, this.model);
     }
   }


### PR DESCRIPTION
using .setDragImage(), which is not supported on IE11

implementing this was trivial, but it opened a browser compatibility can'o'worms (see #7) that may or may not have been worth addressing at this point.
