### PR TITLE
cloning the added card solves the issue

### DIFF
--- a/app/components/bs-row-editor/component.js
+++ b/app/components/bs-row-editor/component.js
@@ -136,7 +136,15 @@ export default Ember.Component.extend({
       return;
     }
     console.log('BS-ROW-EDITOR: Processing DROP for ' + this.get('elementId') + ' caught drop for type ' + td.objectType + ' Action: ' + td.action);
+
+    //default to the card...
     let newCard = td.model;
+    if(td.action ==='add-card'){
+      //but if we are adding it we want a clone
+      newCard = Object.assign({},td.model);
+    }
+
+    
     let targetCard, insertAfter;
     let dropCardInfo = eventBus.get('dropCardInfo');
     if (dropCardInfo) {


### PR DESCRIPTION
Basically clones the `transferData.model` if the action is `add-card`. Prior to this, adding multiple cards in a sequence would result in all of them sharing the same model object. Which led to a wide array of weird behavior

Closes #13
