### PR TITLE
use observer to watch cards.length and remove the row

### DIFF
--- a/app/components/bs-row-editor/component.js
+++ b/app/components/bs-row-editor/component.js
@@ -7,7 +7,12 @@ export default Ember.Component.extend({
   //queue of cards to add... allows us to defer some
   //changes until after css transitions have happened...
   cardQueue: [],
-
+  onNoCards: Ember.observer('model.cards.length', function(){
+    if(this.get('model.cards.length') === 0){
+      console.log('cards is empty, sending onRowDelete');
+      this.sendAction('onRowDelete', this.get('model'));
+    }
+  }),
 
   // insert a card either at the begining
   // or before/after the target card

--- a/app/components/bs-row-editor/template.hbs
+++ b/app/components/bs-row-editor/template.hbs
@@ -4,8 +4,5 @@
                   onUpdateCardResizer=(action 'onUpdateCardResizer' )
                   onCardDelete=(action 'onCardDelete')}}
 {{/each}}
-
-
-  {{card-resizer model=resizerModel
-                 onShift=(action 'onShiftSharedEdge')
-               }}
+{{card-resizer model=resizerModel
+                 onShift=(action 'onShiftSharedEdge')}}

--- a/app/components/layout-section-editor/component.js
+++ b/app/components/layout-section-editor/component.js
@@ -4,6 +4,10 @@ export default Ember.Component.extend({
   tagName:'section',
   classNames:['layout-section-editor'],
 
+  hasRows: Ember.computed('model.rows.length', function(){
+    return this.get('model.rows.length');
+  }),
+
   /**
    * Centralized Handling of Card Removal
    */
@@ -14,6 +18,7 @@ export default Ember.Component.extend({
     //    - delete the row
     if(cards.length === 1){
       console.log('LAYOUT-SECTION-EDITOR:_removeCard - removing last card in row...');
+      Ember.set(row, 'cards',[]);
       this._removeRow(row);
     }else{
 
@@ -41,11 +46,8 @@ export default Ember.Component.extend({
       //expanded width
       let expandedWidth = cardToDelete.width + expandCard.width;
       Ember.set(expandCard, 'width', expandedWidth);
-
-
       //remove the card
       Ember.set(row, 'cards', cards.without( cardToDelete ));
-
     }
   },
 
@@ -53,16 +55,9 @@ export default Ember.Component.extend({
    * Centralized Handling of Row Removal
    */
   _removeRow(row){
-    let rows = this.get('model.rows');
-
-    //Scenarios
-      // Section has one row, and we are deleting it
-      //   - delete the section
-    if( rows.length === 1 ) {
-      this.sendAction('onDeleteSection', this.get('model'));
-    }else{
-      //  Section has > 1 row
-      //    - delete the passed in row
+    //avoid model churn by checking if this actually has the row in it
+    let rowIdx = this.get('model.rows').indexOf(row);
+    if(rowIdx >= 0){
       this.set('model.rows', this.get('model.rows').without(row));
     }
   },

--- a/app/components/layout-section-editor/template.hbs
+++ b/app/components/layout-section-editor/template.hbs
@@ -1,3 +1,4 @@
+{{#if hasRows}}
 <div class="{{containerClass}}" >
   {{#each model.rows as |row|}}
     {{bs-row-editor model=row
@@ -5,5 +6,13 @@
                     onCardDelete=(action 'onCardDelete')
                   }}
   {{/each}}
-
 </div>
+{{else}}
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <h2>Hey No Cards! Drop something here!</h2>
+    </div>
+  </div>
+</div>
+{{/if}}

--- a/app/components/page-layout-editor/component.js
+++ b/app/components/page-layout-editor/component.js
@@ -78,6 +78,7 @@ export default Ember.Component.extend({
   },
 
   _removeSection(section){
+    console.info('PAGE-LAYOUT-EDITOR _removeSection');
     this.set('model.sections', this.get('model.sections').without(section));
   },
 
@@ -91,6 +92,7 @@ export default Ember.Component.extend({
       this.set('moveRow', row);
     },
     onDeleteSection(section){
+      console.info('PAGE-LAYOUT-EDITOR onDeleteSection');
       this._removeSection(section);
     }
 


### PR DESCRIPTION
The part of the `layout-section-editor` component that shows the "Empty - drag something here" should be replaced. I just dropped that in for testing.

![row-b-gone](https://cloud.githubusercontent.com/assets/119129/15167937/1c6002f2-16ea-11e6-9a4d-24e0f10aa195.gif)
