### PR TITLE
drag and drop working in my OSX browsers

### DIFF
--- a/app/components/bs-row-editor/component.js
+++ b/app/components/bs-row-editor/component.js
@@ -157,6 +157,7 @@ export default Ember.Component.extend({
 
     // clear event bus drag info
     this.set('eventBus.transferData', null);
+    event.preventDefault();
   },
 
   dragLeave(){

--- a/app/components/bscard-editor/component.js
+++ b/app/components/bscard-editor/component.js
@@ -33,7 +33,7 @@ export default Ember.Component.extend({
     if (!$target.hasClass('draggable')) {
       return;
     }
-
+    event.dataTransfer.setData('foo/custom','so firefox works');
     // b/c we're dragging from upper right corner,
     // want to shift to the left by width of the element
     // TODO: probably want to set drag image offset x/y dynamically

--- a/app/components/draggable-object/component.js
+++ b/app/components/draggable-object/component.js
@@ -30,12 +30,14 @@ export default Ember.Component.extend({
       model: this.get('model')
     });
 
+    //this is literally needed because "firefox"
+    e.dataTransfer.setData('foo/custom','so firefox works');
     // set drag image?
     if (dragImage && e.dataTransfer && e.dataTransfer.setDragImage) {
       e.dataTransfer.setDragImage(dragImage, this.get('dragImageOffsetX'), this.get('dragImageOffsetY'));
     }
 
-    // let paret know that we've started dragging
+    // let parent know that we've started dragging
     this.sendAction('onDragStart');
   }
 });

--- a/app/components/layout-section-editor/component.js
+++ b/app/components/layout-section-editor/component.js
@@ -201,7 +201,7 @@ export default Ember.Component.extend({
       }
     }
   },
-  drop(/*event*/){
+  drop(event){
     let td = this.get('eventBus.transferData');
     if(!td){
       return;
@@ -210,6 +210,7 @@ export default Ember.Component.extend({
 
     //can accept an add-row action
     if(td.action === 'add-row'){
+      event.preventDefault();
       // create a row object with a single, full width card
       let newCard = td.model;
       // if we're moving a card, need to first


### PR DESCRIPTION
- chrome 50
- firefox 44
- safari 9

Only FireFox needed changes. Essentially setting data on the event...
`event.dataTransfer.setData('foo/custom','so firefox works');`

If the mime-type is set to `text/plain` it seems to fire a navigation event O_o
