### PR TITLE
quick and dirty empty section drop target

### DIFF
--- a/app/components/drop-preview/component.js
+++ b/app/components/drop-preview/component.js
@@ -84,6 +84,16 @@ export default Ember.Component.extend({
           width = pos.width;
           left=pos.left;
           break;
+
+        case 'section-empty':
+          this.set('dockMessage', this.get('emptySectionMessage'));
+          this.set('layoutCoordinator.draggingProperties.dropTargetType', 'section');
+          pos = this.get('layoutCoordinator.draggingProperties.targetSection.componentPosition');
+          top=pos.top;
+          height=pos.height;
+          width = pos.width;
+          left=pos.left;
+          break;
       }
 
       styleString = Ember.String.htmlSafe(`top:${top}px; left:${left}px;height:${height}px;width:${width}px;`);
@@ -98,7 +108,7 @@ export default Ember.Component.extend({
         styleString = Ember.String.htmlSafe(`left:${draggingPosition.left}px;top:${draggingPosition.top}px;`);
       }
     }
-    
+
     return styleString;
   })
 

--- a/app/components/empty-section-drop-target/component.js
+++ b/app/components/empty-section-drop-target/component.js
@@ -1,0 +1,55 @@
+/**
+ * empty-section-drop-target/component.js
+ */
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames:['empty-section-drop-target'],
+  attributeBindings:['style'],
+  layoutCoordinator: Ember.inject.service('layout-coordinator'),
+  sectionComponent:null,
+  targetContainerStyle:'',
+  hasDockingTarget: Ember.computed.notEmpty('dockingTarget'),
+  dockingTarget: Ember.computed.alias('layoutCoordinator.draggingProperties.dockingTarget'),
+
+  init(){
+    this._super(...arguments);
+    //add handlers for layoutCoordinator events
+    this.get('layoutCoordinator').on('showEmptySectionDropTarget', Ember.run.bind(this, this.showEmptySectionDropTarget));
+  },
+  willDestroyElement(){
+    this.get('layoutCoordinator').off('showEmptySectionDropTarget', this.showEmptySectionDropTarget);
+  },
+
+  showEmptySectionDropTarget(sectionComponent){
+    if(sectionComponent){
+      this.set('sectionComponent', sectionComponent);
+      this.updateTargetStyle(sectionComponent.get('componentPosition'));
+    }else{
+      this.set('sectionComponent',null);
+      this.updateTargetStyle( null );
+    }
+  },
+
+  updateTargetStyle(componentPosition){
+    let styleString = Ember.String.htmlSafe('display:none;');
+    let pos = componentPosition;
+    if(pos){
+      styleString = Ember.String.htmlSafe('top:' + pos.top + 'px; left:' + pos.left + 'px;height:' + pos.height+ 'px;width:' + pos.width + 'px;');
+    }
+    this.set('targetContainerStyle',  styleString);
+  },
+
+  actions: {
+    /**
+     * fires on mouseEnter & mouseLeave for the targets
+     */
+    updateDockingTarget(dockTargetName){
+      if(this.get('layoutCoordinator.draggingProperties')){
+        console.log('empty-section-drop-target setting dropTargetName to ' + dockTargetName)
+        this.set('layoutCoordinator.draggingProperties.dockingTarget', dockTargetName);
+      }
+    }
+  }
+
+});

--- a/app/components/empty-section-drop-target/template.hbs
+++ b/app/components/empty-section-drop-target/template.hbs
@@ -1,0 +1,6 @@
+<div class="target-container" style={{targetContainerStyle}}>
+  <div class="section-drop-target empty {{if (eq dockingTarget 'section-empty') 'hover'}}"
+    {{action "updateDockingTarget" "section-empty" true on="mouseEnter"}}
+    {{action "updateDockingTarget" on="mouseLeave"}}
+    ></div>
+</div>

--- a/app/components/page-layout-editor/template.hbs
+++ b/app/components/page-layout-editor/template.hbs
@@ -23,10 +23,12 @@
   onRemoveSection=(action 'onRemoveSection')}}
 {{card-drop-targets }}
 {{row-drop-targets }}
+{{empty-section-drop-target }}
 {{drop-preview
   dragMessage="Drag to new position"
   dockLeftMessage="Split and Dock to the left"
   dockRightMessage="Split and Dock to the right"
   dockTopMessage="Add to top"
   dockBottomMessage="Add to bottom"
+  emptySectionMessage="Add to section"
 }}

--- a/app/layout-coordinator/service.js
+++ b/app/layout-coordinator/service.js
@@ -178,9 +178,12 @@ export default Ember.Service.extend(Ember.Evented, {
     //SECTIONS
     let sectionFound = this.getComponentAtPosition('section', position);
     if(sectionFound){
+      let dragType = this.get('draggingProperties.dragType');
       //only show the section targets if we are dragging a section
-      if(this.get('draggingProperties.dragType') === 'section'){
+      if(dragType === 'section'){
         this.trigger( 'showRowDropTargets' , sectionFound );
+      } else if (dragType === 'card' && !sectionFound.get('hasRows')) {
+        this.trigger('showEmptySectionDropTarget', sectionFound);
       }
       this.set('draggingProperties.targetSection', sectionFound);
     }else{
@@ -197,12 +200,15 @@ export default Ember.Service.extend(Ember.Evented, {
     console.log('----------------------------');
     console.log(' DROP EVENT:');
     if(draggingProperties.targetCard){
-        console.log('   TARGET CARD:' + draggingProperties.targetCard.get('elementId'));
+      console.log('   TARGET CARD:' + draggingProperties.targetCard.get('elementId'));
     }else{
       console.log('   TARGET CARD: null' );
     }
-
-    console.log('   TARGET ROW :' + draggingProperties.targetRow.get('elementId'));
+    if(draggingProperties.targetRow){
+      console.log('   TARGET ROW :' + draggingProperties.targetRow.get('elementId'));
+    }else{
+      console.log('   TARGET ROW: null' );
+    }
     console.log('   TARGET SECTION :' + draggingProperties.targetSection.get('elementId'));
     console.log('   ----------------------------');
     console.log('   DOCKING TARGET:' + draggingProperties.dockingTarget);
@@ -213,6 +219,7 @@ export default Ember.Service.extend(Ember.Evented, {
     //hide the drop targets
     this.trigger('showCardDropTargets',null);
     this.trigger('showRowDropTargets',null);
+    this.trigger('showEmptySectionDropTarget',null);
 
     //expand out of the properties into vars we can reason about
     let dragType = draggingProperties.component.get('dragType');
@@ -240,6 +247,10 @@ export default Ember.Service.extend(Ember.Evented, {
         if(dropTargetType === 'row'){
           targetSection.insertCardIntoNewRow(clone, targetRow.get('model'), dockingTarget);
         }
+        //and we are DROPPING on an empty section
+        if(dropTargetType === 'section'){
+          targetSection.insertCardIntoNewRow(clone, null, dockingTarget);
+        }
       }
       if(dragAction === 'move'){
         //if we are moving, lets make a clone of the mode, then remove it from where it was
@@ -263,6 +274,10 @@ export default Ember.Service.extend(Ember.Evented, {
         //and we are DROPPING on a ROW-TARGET
         if(dropTargetType === 'row'){
           targetSection.insertCardIntoNewRow(clone, targetRow.get('model'), dockingTarget);
+        }
+        //and we are DROPPING on a ROW-TARGET
+        if(dropTargetType === 'section'){
+          targetSection.insertCardIntoNewRow(clone, null, dockingTarget);
         }
       }
     }//dragType===card

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -13,6 +13,7 @@ $link-color: #555555;
 @import 'section-controls';
 @import 'card-drop-targets';
 @import 'row-drop-targets';
+@import 'empty-section-drop-target';
 @import 'page-layout-editor';
 @import 'blank-card';
 

--- a/app/styles/empty-section-drop-target.scss
+++ b/app/styles/empty-section-drop-target.scss
@@ -1,0 +1,36 @@
+.empty-section-drop-target{
+  .target-container{
+    display: block;
+    position: absolute;
+    // outline: 1px dashed purple;
+
+    .section-drop-target {
+
+      position: absolute;
+      // TODO: correct size for image
+      width: 60px;
+      height: 16px;
+      -moz-user-select: none;
+      -khtml-user-select: none;
+      -webkit-user-select: none;
+      cursor: default;
+      z-index: 580;
+      background-color: #f8f8f8;
+      background-position: 0 0;
+      margin: auto;
+      box-shadow: 0 0 20px 3px rgba(0, 0, 0, .2);
+
+      &.empty {
+        // TODO: correct position foe image
+        top: 20px;
+        left: calc(50% - 60px);
+        // TODO: need dock-center.png
+        background-image: url("./images/dock-top.png");
+      }
+      &.empty.hover {
+        // TODO: need dock-center-sel.png
+        background-image: url("./images/dock-top-sel.png");
+      }
+    }
+  }
+}

--- a/tests/integration/components/empty-section-drop-target/component-test.js
+++ b/tests/integration/components/empty-section-drop-target/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('empty-section-drop-target', 'Integration | Component | empty section drop target', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{empty-section-drop-target}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#empty-section-drop-target}}
+      template block text
+    {{/empty-section-drop-target}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
dragging over empty section shows a drop target
which will preview as filling the whole row
dropping will create a new row and add the card full width (12)

TODO:
- need better image/position for drop target (currently using the row-top image)

![dnd-empty-section](https://cloud.githubusercontent.com/assets/662944/15308461/818d38be-1b92-11e6-88bb-5e7481bc0227.gif)
